### PR TITLE
Fix Netlify build by installing dev dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,8 @@
   # Comando de instalación
   base = "."
 
-  # Comando de build - usar npm install en lugar de npm ci para asegurar devDependencies
-  command = "npm install && npm run build"
+  # Comando de build - asegurar que se instalen las devDependencies necesarias para Vite
+  command = "npm install --include=dev && npm run build"
 
   # Directorio donde se genera el build
   publish = "dist"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,9 +7,13 @@
 
   # Directorio donde se genera el build
   publish = "dist"
-  
+
   # Directorio de las serverless functions
   functions = "netlify/functions"
+
+# Environment variables for build process
+[build.environment]
+  NODE_ENV = "production"
 
 # Redirects para mapear rutas de API a serverless functions
 [[redirects]]


### PR DESCRIPTION
## Purpose

The user was experiencing a Netlify build failure where the `vite` command was not found during the build process. The build was failing with exit code 127, indicating that the Vite build tool was not available in the production environment. This was preventing successful deployment of the React application.

## Code changes

- Updated the build command in `netlify.toml` to use `npm install --include=dev` instead of `npm install` to ensure development dependencies (including Vite) are installed during the build process
- Added a new `[build.environment]` section with `NODE_ENV = "production"` to properly configure the build environment
- Improved code comments to clarify the purpose of including dev dependencies for Vite

These changes ensure that Vite and other necessary build tools are available during the Netlify build process, resolving the "vite: not found" error.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 53`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7fa801491c154df995f6b257d60e5b61/vortex-realm)

👀 [Preview Link](https://7fa801491c154df995f6b257d60e5b61-vortex-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7fa801491c154df995f6b257d60e5b61</projectId>-->
<!--<branchName>vortex-realm</branchName>-->