### PR TITLE
Add DATABASE_URL support to neon-diagnostic function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/neon/diagnostic"
+  to = "/.netlify/functions/neon-diagnostic"
+  status = 200
+
+[[redirects]]
   from = "/netlify/functions/neon-products"
   to = "/.netlify/functions/neon-products"
   status = 200
@@ -41,7 +46,12 @@
   to = "/.netlify/functions/neon-sync"
   status = 200
 
-# Redirect para SPA routing (React Router)
+[[redirects]]
+  from = "/netlify/functions/neon-diagnostic"
+  to = "/.netlify/functions/neon-diagnostic"
+  status = 200
+
+# Redirect para SPA routing (React Router) - DEVE SER O ÚLTIMO
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/neon-diagnostic.js
+++ b/netlify/functions/neon-diagnostic.js
@@ -51,7 +51,7 @@ exports.handler = async (event, context) => {
     diagnostic.details.environmentVariables = envVars;
 
     // 2. Verificar qual connection string usar
-    const connectionString = process.env.NEON_CONNECTION_STRING || process.env.VITE_NEON_CONNECTION_STRING;
+    const connectionString = process.env.DATABASE_URL || process.env.NEON_CONNECTION_STRING || process.env.VITE_NEON_CONNECTION_STRING;
     
     if (!connectionString) {
       diagnostic.details.connectionStringStatus = 'not_found';

--- a/netlify/functions/neon-diagnostic.js
+++ b/netlify/functions/neon-diagnostic.js
@@ -56,7 +56,7 @@ exports.handler = async (event, context) => {
     
     if (!connectionString) {
       diagnostic.details.connectionStringStatus = 'not_found';
-      diagnostic.message = 'Nenhuma connection string encontrada (NEON_CONNECTION_STRING ou VITE_NEON_CONNECTION_STRING)';
+      diagnostic.message = 'Nenhuma connection string encontrada (DATABASE_URL, NEON_CONNECTION_STRING ou VITE_NEON_CONNECTION_STRING)';
       diagnostic.success = false;
     } else {
       diagnostic.details.connectionStringStatus = 'found';

--- a/netlify/functions/neon-diagnostic.js
+++ b/netlify/functions/neon-diagnostic.js
@@ -36,6 +36,7 @@ exports.handler = async (event, context) => {
   try {
     // 1. Verificar variáveis de ambiente disponíveis
     const envVars = {
+      DATABASE_URL: !!process.env.DATABASE_URL,
       NEON_CONNECTION_STRING: !!process.env.NEON_CONNECTION_STRING,
       VITE_NEON_CONNECTION_STRING: !!process.env.VITE_NEON_CONNECTION_STRING,
       VITE_NEON_PROJECT_ID: !!process.env.VITE_NEON_PROJECT_ID,

--- a/netlify/functions/neon-diagnostic.js
+++ b/netlify/functions/neon-diagnostic.js
@@ -60,7 +60,13 @@ exports.handler = async (event, context) => {
       diagnostic.success = false;
     } else {
       diagnostic.details.connectionStringStatus = 'found';
-      diagnostic.details.connectionStringSource = process.env.NEON_CONNECTION_STRING ? 'NEON_CONNECTION_STRING' : 'VITE_NEON_CONNECTION_STRING';
+      if (process.env.DATABASE_URL) {
+        diagnostic.details.connectionStringSource = 'DATABASE_URL';
+      } else if (process.env.NEON_CONNECTION_STRING) {
+        diagnostic.details.connectionStringSource = 'NEON_CONNECTION_STRING';
+      } else {
+        diagnostic.details.connectionStringSource = 'VITE_NEON_CONNECTION_STRING';
+      }
       
       // Mascarar a connection string para segurança
       const maskedConnectionString = connectionString.replace(


### PR DESCRIPTION
## Purpose

Based on the diagnostic results showing issues with Netlify Functions returning non-JSON content and missing diagnostic functionality, this PR enhances the neon-diagnostic function to better support database connectivity troubleshooting by adding support for the standard DATABASE_URL environment variable.

## Code changes

### netlify.toml
- Added new redirect routes for `/api/neon/diagnostic` and `/netlify/functions/neon-diagnostic` to properly route to the neon-diagnostic function
- Moved SPA routing redirect to the end with clarifying comment to ensure it doesn't interfere with API routes

### netlify/functions/neon-diagnostic.js
- Added `DATABASE_URL` environment variable check to the diagnostic function
- Updated connection string priority order: `DATABASE_URL` → `NEON_CONNECTION_STRING` → `VITE_NEON_CONNECTION_STRING`
- Enhanced error messaging to include all three possible connection string sources
- Improved connection string source detection logic to properly identify which variable is being used

These changes improve the diagnostic capabilities and ensure proper routing for the neon-diagnostic function while maintaining backward compatibility.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2238effc092a41c0a7d03feabbfe9b2c/curry-zone)

👀 [Preview Link](https://2238effc092a41c0a7d03feabbfe9b2c-curry-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2238effc092a41c0a7d03feabbfe9b2c</projectId>-->
<!--<branchName>curry-zone</branchName>-->